### PR TITLE
Fix: .distignore の wordpress を行頭アンカーし配下の誤除外を防ぐ

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -20,7 +20,7 @@ phpunit.xml.dist
 README.md
 Development.md
 webpack.config.js
-wordpress
+/wordpress
 bin
 tests
 hamethread.php.bak


### PR DESCRIPTION
## 背景

`wp dist-archive` が参照する `.distignore` は `.gitignore` と同じマッチ規則で、行頭スラッシュなしのパターンは全階層に再帰マッチします。そのため `wordpress` と書くと、ルート直下の `wordpress` ディレクトリだけでなく、将来 `vendor/**/wordpress` のような配下のパスまで誤って除外してしまう時限爆弾になります。

ルート直下のみを除外したい場合は `/wordpress` のように行頭アンカーを付ける必要があります。

## 変更内容

- `.distignore` の `wordpress` を `/wordpress` に変更し、ルート直下のみに限定。
- `.wordpress-org` 等の他のエントリは対象外。

```diff
-wordpress
+/wordpress
```