### PR TITLE
#25 リリースビルドのバージョン番号が空になる不具合を修正

### DIFF
--- a/.github/workflows/wordpress.yml
+++ b/.github/workflows/wordpress.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: '20'
 
       - name: Build package.
-        run: bash bin/build.sh ${{ github.event.release.tag_name }}
+        run: bash bin/build.sh ${{ github.ref }}
 
       - name: Zip Archive
         run: |


### PR DESCRIPTION
## 概要

Issue #25 の修正。リリースビルドの `hamethread.php` / `readme.txt` からバージョン番号が消えていた問題を直す。

## 原因

`.github/workflows/wordpress.yml` のトリガーは `push: tags` だが、28行目で `${{ github.event.release.tag_name }}` を参照していた。`release.tag_name` は `release` イベントでしか存在せず、`push` イベントのペイロードには `release` オブジェクトが無いため**空文字**に評価される。

その結果 `bin/build.sh` に空の引数が渡り、以下の `sed` でバージョン文字列が空になっていた。

```bash
sed -i.bak "s/Version: .*/Version: ${VERSION}/g" ./hamethread.php   # → "Version: "
sed -i.bak "s/^Stable tag: .*/Stable tag: ${VERSION}/g" ./readme.txt # → "Stable tag: "
```

## 修正

`bin/build.sh` は冒頭で `refs/tags/` プレフィックスを剥がすロジックを持っており、元々 `github.ref` を受け取る前提で書かれている。そこで渡す値を `${{ github.ref }}` に修正した。

- `github.ref` → `refs/tags/1.2.0` → build.sh が prefix を剥がして `1.2.0` ✅

`if: contains(github.ref, 'tags/')` も `github.ref` 系で揃うため整合する。

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)