### PR TITLE
PHPUnitのキャッシュファイルを .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,6 @@ assets
 wp-dependencies.json
 languages/*.mo
 languages/*.json
+
+# PHPUnit
+.phpunit.result.cache

--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # HameThread
 
-Contributors: Takahashi_Fumiki, hametuha
-Tags: faq,thread,forum
-Tested up to: 6.8
-Stable tag: nightly
-License: GPL 3.0 or later
+Contributors: hametuha, Takahashi_Fumiki  
+Tags: faq,thread,forum 
+Tested up to: 6.8 
+Stable tag: nightly 
+License: GPL 3.0 or later 
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 Form plugin for hametuha.
 
-[![Travis CI](https://travis-ci.org/hametuha/hamethread.svg?branch=master)](https://travis-ci.org/hametuha/hamethread)
+[![Hamethread Test](https://github.com/hametuha/hamethread/actions/workflows/test.yml/badge.svg)](https://github.com/hametuha/hamethread/actions/workflows/test.yml)
 
 ## Description
 


### PR DESCRIPTION
## 概要

`.phpunit.result.cache` はPHPUnit実行時に自動生成されるローカルキャッシュ。リポジトリに追跡される必要がないため `.gitignore` に追加する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)