### PR TITLE
Fix: WooCommerce有効環境でのFatal error修正とリグレッションテスト追加 (#46)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -54,6 +54,25 @@ wp-dependencies.jsonで依存関係を管理:
 - `hamethread-hashboard` CSSは `bootstrap` に依存
 - `hamethread`, `hamethread-comment` はBootstrapに依存しない
 
+### WooCommerce統合について
+
+`SupportWooCommerce.php`（`Hooks/`配下なので `Thread` 初期化時に自動ロード）が、WooCommerceの**マイアカウント画面**にサポート機能を追加する。kunoichi marketでは商品サポートページとして本番利用している。
+
+- **WooCommerceがない環境**: `init()` 冒頭の `function_exists( 'WC' )` チェックで何もしない。
+- **WooCommerceがある環境**: マイアカウントに「Support」メニューとエンドポイント（`/my-account/support/`）を追加し、ログインユーザー自身の `thread` 投稿一覧をページネーション付きで表示する。
+
+| 構成要素 | 役割 |
+|----------|------|
+| `Hooks/SupportWooCommerce.php` | フック登録（`WC()` 存在時のみ起動） |
+| `template-parts/woocommerce-my-account.php` | サポート一覧テンプレート |
+| `src/scss/hamethread-woocommerce.scss` → `hamethread-woocommerce` ハンドル | 一覧用CSS（Bootstrap非依存） |
+
+アセットは個別登録せず、`Thread::register_assets()` が `wp-dependencies.json` から一括登録する（`render_support_list()` 内で `wp_enqueue_style( 'hamethread-woocommerce' )` するだけ）。**個々のHookクラスに `register_assets` を `add_action` してはいけない**（#46 のFatal errorの原因）。
+
+ローカルでの動作確認は `.wp-env.json` にWooCommerceを含めてあるため、`http://localhost:8888` で再現できる。リグレッションテストは `tests/TestWooCommerce.php`。
+
+> 既知の課題: `paginate()` がBootstrapクラス（`pagination` / `page-item` / `page-link`）のマークアップを出力するが、`hamethread-woocommerce` CSSはBootstrap非依存。ストアフロントにBootstrapが無い環境ではページネーションが未スタイルになる（別途issue化予定）。
+
 ## ビルドシステム
 
 ### @kunoichi/grab-deps

--- a/.wp-env.json
+++ b/.wp-env.json
@@ -2,7 +2,8 @@
 	"plugins": [
 		".",
 		"https://downloads.wordpress.org/plugin/plugin-check.latest-stable.zip",
-		"https://downloads.wordpress.org/plugin/query-monitor.latest-stable.zip"
+		"https://downloads.wordpress.org/plugin/query-monitor.latest-stable.zip",
+		"https://downloads.wordpress.org/plugin/woocommerce.latest-stable.zip"
 	],
 	"mappings": {
 		"wp-content/mu-plugins/hamethread-dev.php": "./tests/hashboard.php"

--- a/app/Hametuha/Thread/Hooks/SupportWooCommerce.php
+++ b/app/Hametuha/Thread/Hooks/SupportWooCommerce.php
@@ -21,7 +21,6 @@ class SupportWooCommerce extends Singleton {
 		}
 		add_filter( 'woocommerce_account_menu_items', [ $this, 'woocommerce_link' ], 20 );
 		add_action( 'init', [ $this, 'add_endpoint' ] );
-		add_action( 'init', [ $this, 'register_assets' ] );
 		add_filter( 'query_vars', function ( $vars ) {
 			$vars[] = 'hamethread-support';
 			return $vars;

--- a/tests/TestWooCommerce.php
+++ b/tests/TestWooCommerce.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * WooCommerce support integration tests.
+ *
+ * @package hamethread
+ */
+
+use Hametuha\Thread\Hooks\SupportWooCommerce;
+
+if ( ! function_exists( 'WC' ) ) {
+	/**
+	 * Minimal WooCommerce stub.
+	 *
+	 * SupportWooCommerce::init() bails out unless WooCommerce is active
+	 * ( `function_exists( 'WC' )` ). The CI test environment does not install
+	 * WooCommerce, so we provide a no-op stub to let the hook registration run.
+	 * When the real WooCommerce is loaded this declaration is skipped.
+	 *
+	 * @return null
+	 */
+	function WC() {
+		return null;
+	}
+}
+
+/**
+ * Ensure SupportWooCommerce only registers callable hook callbacks.
+ *
+ * Regression test for #46: commit cb89a1e removed the `register_assets()`
+ * method but left `add_action( 'init', [ $this, 'register_assets' ] )` behind,
+ * which threw a fatal error on every WooCommerce-enabled site. This test
+ * re-runs the hook registration and asserts that every callback pointing back
+ * to the instance resolves to a real, callable method.
+ */
+class TestWooCommerce extends WP_UnitTestCase {
+
+	/**
+	 * Every hook SupportWooCommerce registers must be callable.
+	 */
+	public function test_hook_callbacks_are_callable() {
+		// The Singleton caches its instance and guards init() behind WC(),
+		// so build a fresh instance and invoke the protected init() directly.
+		$ref      = new ReflectionClass( SupportWooCommerce::class );
+		$instance = $ref->newInstanceWithoutConstructor();
+		$init     = $ref->getMethod( 'init' );
+		$init->setAccessible( true );
+		$init->invoke( $instance );
+
+		// Collect every registered callback that is bound to this instance.
+		global $wp_filter;
+		$invalid = [];
+		foreach ( $wp_filter as $tag => $hook ) {
+			foreach ( $hook->callbacks as $callbacks ) {
+				foreach ( $callbacks as $cb ) {
+					$fn = $cb['function'];
+					if ( is_array( $fn ) && isset( $fn[0] ) && $fn[0] === $instance && ! is_callable( $fn ) ) {
+						$invalid[] = $tag . ' => ' . $fn[1];
+					}
+				}
+			}
+		}
+
+		$this->assertSame( [], $invalid, 'Non-callable hook callbacks: ' . implode( ', ', $invalid ) );
+	}
+}


### PR DESCRIPTION
## 概要

WooCommerce有効環境で `init` フック実行時に発生する Fatal error（#46）を修正する。

```
Fatal error: ... class Hametuha\Thread\Hooks\SupportWooCommerce does not have a method "register_assets"
```

## 原因

時系列の調査で根本原因を特定:

| commit | 内容 |
|--------|------|
| `b1e3df5` (WooCommerce対応追加) | `add_action('init', register_assets)` **と** `register_assets()` メソッド本体を両方定義 |
| `cb89a1e` (2025-11-12 依存関係刷新) | アセット登録を `Thread::register_assets()`（`wp-dependencies.json` 一括登録）へ集約した際、**`register_assets()` メソッド本体だけ削除し `add_action(...)` の行を消し忘れた** ← これがバグ |

`hamethread-woocommerce` アセットは `Thread::register_assets()` が登録済みのため、`add_action` 行は不要なデッドコードだった。

> 補足: kunoichi market（商品サポートページで本番利用）は Bootstrap 依存除去版（このリグレッション以前）を利用中のため、現時点では顕在化していない。次回更新時に必要な修正。

## 変更内容

- **修正**: `SupportWooCommerce::init()` から `add_action( 'init', [ $this, 'register_assets' ] )` を削除。
- **テスト**: `tests/TestWooCommerce.php` を追加。`SupportWooCommerce` が登録する全フックのコールバックが callable であることを検証。WooCommerce非依存（スタブ）でCIでも実行され、**バグ当時は `init => register_assets` を検出して失敗する**ことを確認済み。
- **wp-env**: `.wp-env.json` に WooCommerce を追加し、ローカルでサポートページを実機確認できるようにした。
- **ドキュメント**: `CLAUDE.md` を `.claude/` へ移動し、WooCommerce連携（本番利用箇所・WC()ゲート・アセット構成・再発防止指針）を文書化。

## 検証

- `npm test` → OK (2 tests, 6 assertions)
- バグ再現行を戻すとテストが失敗することを確認（`Non-callable hook callbacks: init => register_assets`）
- `composer lint`（PHPCS）/ `composer phpstan` ともにクリーン

## 残課題（別issue化予定）

`paginate()` がBootstrapクラス（`pagination` / `page-item` / `page-link`）を出力するが `hamethread-woocommerce` CSSはBootstrap非依存。ストアフロントでページネーションが未スタイルになる。

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)