### PR TITLE
Fix: ページネーションをBootstrap非依存の共通マークアップに統一 (#48)

### DIFF
--- a/app/Hametuha/Thread/Hooks/SupportWooCommerce.php
+++ b/app/Hametuha/Thread/Hooks/SupportWooCommerce.php
@@ -80,7 +80,7 @@ class SupportWooCommerce extends Singleton {
 	 * @return string
 	 */
 	public function paginate( $pagination, $query ) {
-		$link = paginate_links( [
+		$links = paginate_links( [
 			'base'      => untrailingslashit( wc_get_page_permalink( 'myaccount' ) ) . '/support/%_%',
 			'format'    => '%#%',
 			'total'     => $query->max_num_pages,
@@ -89,23 +89,6 @@ class SupportWooCommerce extends Singleton {
 			'current'   => max( 1, get_query_var( 'hamethread-support' ) ),
 			'type'      => 'array',
 		] );
-		if ( ! $link ) {
-			return '';
-		}
-		ob_start();
-		?>
-		<nav aria-label="Page navigation example" class="mt-4">
-			<ul class="pagination">
-				<?php foreach ( $link as $l ) : ?>
-					<li class="page-item<?php echo false === strpos( $l, '<span' ) ? '' : ' active'; ?>">
-						<?php echo preg_replace( '/(?<!i) class=[\'"][^\'"]+[\'"]/u', ' class="page-link"', $l ); ?>
-					</li>
-				<?php endforeach; ?>
-			</ul>
-		</nav>
-		<?php
-		$pagination = ob_get_contents();
-		ob_end_clean();
-		return $pagination;
+		return hamethread_pagination_html( $links );
 	}
 }

--- a/functions.php
+++ b/functions.php
@@ -452,33 +452,56 @@ function hamethread_last_commented( $no_comment = '---', $post = null, $format =
 }
 
 /**
+ * Build pagination markup from an array of page links.
+ *
+ * Accepts the `type => array` output of `paginate_links()` /
+ * `paginate_comments_links()` and wraps it in Bootstrap-independent markup
+ * using `hamethread-pagination` classes. Styles live in `src/scss/_pagination.scss`.
+ *
+ * @param string[]|string|null $links Array of anchor/span HTML for each page,
+ *                                    as returned by paginate_links() / paginate_comments_links().
+ * @param string               $label aria-label for the <nav> element.
+ * @return string Empty string when there is nothing to paginate.
+ */
+function hamethread_pagination_html( $links, $label = '' ) {
+	if ( ! is_array( $links ) || ! $links ) {
+		return '';
+	}
+	$label = $label ? $label : __( 'Pagination', 'hamethread' );
+	$items = array_map( function ( $link ) {
+		$classes = [ 'hamethread-pagination-item' ];
+		if ( false !== strpos( $link, 'current' ) ) {
+			$classes[] = 'is-current';
+		} elseif ( false !== strpos( $link, 'dots' ) ) {
+			$classes[] = 'is-dots';
+		} elseif ( false !== strpos( $link, 'prev' ) ) {
+			$classes[] = 'is-prev';
+		} elseif ( false !== strpos( $link, 'next' ) ) {
+			$classes[] = 'is-next';
+		}
+		// Rewrite the link element's own class (the first class attribute) to ours.
+		$link = preg_replace( '/class=([\'"]).*?\1/', 'class="hamethread-pagination-link"', $link, 1 );
+		return sprintf( '<li class="%s">%s</li>', esc_attr( implode( ' ', $classes ) ), $link );
+	}, $links );
+	return sprintf(
+		'<nav class="hamethread-pagination" aria-label="%s"><ul class="hamethread-pagination-list">%s</ul></nav>',
+		esc_attr( $label ),
+		implode( '', $items )
+	);
+}
+
+/**
  * Display comment links
  *
  * @return string
  */
 function hamethread_comment_links() {
-	$link = paginate_comments_links( [
+	$links = paginate_comments_links( [
 		'echo' => false,
 		'type' => 'array',
 	] );
-	if ( $link ) {
-		$link = array_map( function ( $l ) {
-			$classes = [ 'page-item' ];
-			if ( false !== strpos( $l, 'current' ) ) {
-				$classes[] = 'active';
-			} elseif ( false !== strpos( $l, 'dot' ) ) {
-				$classes[] = 'disabled';
-			}
-
-			return sprintf( '<li class="%s">%s</li>', implode( ' ', $classes ), $l );
-		}, $link );
-		array_unshift( $link, '<ul class="pagination">' );
-		array_unshift( $link, sprintf( '<nav aria-label="%s" class="text-center">', esc_html__( 'Comments Pagination', 'hamethread' ) ) );
-		array_push( $link, '</ul>' );
-		array_push( $link, '</nav>' );
-		$link = implode( "\n", $link );
-	}
-	return apply_filters( 'hamethread_comment_links', $link );
+	$html  = hamethread_pagination_html( $links, __( 'Comments Pagination', 'hamethread' ) );
+	return apply_filters( 'hamethread_comment_links', $html );
 }
 
 /**

--- a/src/scss/_pagination.scss
+++ b/src/scss/_pagination.scss
@@ -1,0 +1,58 @@
+// Shared pagination styles (Bootstrap-independent).
+// Used by both the comment list ( hamethread.scss ) and the WooCommerce
+// support list ( hamethread-woocommerce.scss ). Markup is produced by
+// `hamethread_pagination_html()` in functions.php.
+
+.hamethread-pagination {
+	margin-top: 1.5rem;
+
+	&-list {
+		display: flex;
+		flex-wrap: wrap;
+		gap: 0.25rem;
+		justify-content: center;
+		margin: 0;
+		padding: 0;
+		list-style: none;
+	}
+
+	&-link {
+		display: inline-flex;
+		align-items: center;
+		justify-content: center;
+		min-width: 2.25rem;
+		height: 2.25rem;
+		padding: 0 0.5rem;
+		border: 1px solid #ddd;
+		border-radius: 4px;
+		color: inherit;
+		line-height: 1;
+		text-decoration: none;
+
+		&:link,
+		&:visited {
+			color: inherit;
+		}
+
+		&:hover,
+		&:focus {
+			background-color: #f5f5f5;
+		}
+	}
+
+	// Current page.
+	&-item.is-current &-link {
+		background-color: #333;
+		border-color: #333;
+		color: #fff;
+		cursor: default;
+		pointer-events: none;
+	}
+
+	// Ellipsis ( "…" ) between page numbers.
+	&-item.is-dots &-link {
+		border-color: transparent;
+		cursor: default;
+		pointer-events: none;
+	}
+}

--- a/src/scss/hamethread-woocommerce.scss
+++ b/src/scss/hamethread-woocommerce.scss
@@ -1,3 +1,5 @@
+@use 'pagination';
+
 .hamethread-my-threads {
 
 	&-item {

--- a/src/scss/hamethread.scss
+++ b/src/scss/hamethread.scss
@@ -7,6 +7,8 @@
  * @deps dashicons
  */
 
+@use 'pagination';
+
 $small-screen: 480px;
 
 .hamethread-form {

--- a/tests/TestPagination.php
+++ b/tests/TestPagination.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Pagination markup helper tests.
+ *
+ * @package hamethread
+ */
+
+/**
+ * Tests for hamethread_pagination_html().
+ *
+ * Covers the markup produced for #48 (Bootstrap-independent pagination shared
+ * by the comment list and the WooCommerce support list).
+ */
+class TestPagination extends WP_UnitTestCase {
+
+	/**
+	 * Empty or non-array input yields an empty string.
+	 */
+	public function test_empty_input() {
+		$this->assertSame( '', hamethread_pagination_html( [] ) );
+		$this->assertSame( '', hamethread_pagination_html( null ) );
+		$this->assertSame( '', hamethread_pagination_html( '' ) );
+	}
+
+	/**
+	 * Representative paginate_links() output is converted to hamethread markup.
+	 */
+	public function test_markup_and_state_classes() {
+		$links = [
+			'<a class="prev page-numbers" href="/page/1"><span class="dashicons dashicons-arrow-left-alt2"></span></a>',
+			'<a class="page-numbers" href="/page/1">1</a>',
+			'<span aria-current="page" class="page-numbers current">2</span>',
+			'<span class="page-numbers dots">&hellip;</span>',
+			'<a class="next page-numbers" href="/page/3"><span class="dashicons dashicons-arrow-right-alt2"></span></a>',
+		];
+
+		$html = hamethread_pagination_html( $links, 'My Pages' );
+
+		// Wrapper markup.
+		$this->assertStringContainsString( '<nav class="hamethread-pagination" aria-label="My Pages">', $html );
+		$this->assertStringContainsString( '<ul class="hamethread-pagination-list">', $html );
+
+		// State modifiers on the list items.
+		$this->assertStringContainsString( 'hamethread-pagination-item is-prev', $html );
+		$this->assertStringContainsString( 'hamethread-pagination-item is-current', $html );
+		$this->assertStringContainsString( 'hamethread-pagination-item is-dots', $html );
+		$this->assertStringContainsString( 'hamethread-pagination-item is-next', $html );
+
+		// Link element classes are rewritten to ours.
+		$this->assertStringContainsString( 'class="hamethread-pagination-link"', $html );
+
+		// No Bootstrap / raw WordPress classes leak through on the link element.
+		$this->assertStringNotContainsString( 'page-item', $html );
+		$this->assertStringNotContainsString( 'class="pagination"', $html );
+		$this->assertStringNotContainsString( 'class="page-numbers"', $html );
+
+		// Inner dashicon markup (a nested element) is preserved.
+		$this->assertStringContainsString( 'dashicons-arrow-left-alt2', $html );
+		$this->assertStringContainsString( 'dashicons-arrow-right-alt2', $html );
+	}
+
+	/**
+	 * The default aria-label is applied when none is given.
+	 */
+	public function test_default_label() {
+		$html = hamethread_pagination_html( [ '<a class="page-numbers" href="/p/2">2</a>' ] );
+		$this->assertStringContainsString( 'aria-label="Pagination"', $html );
+	}
+}


### PR DESCRIPTION
## 概要

WooCommerceサポート一覧とコメント一覧のページネーションが、どちらも **Bootstrapクラス**（`pagination` / `page-item` / `page-link`）を出力していたが、プラグイン側に対応するスタイルが無くBootstrap前提だった。Bootstrap除去環境（kunoichi market等）では**両方とも未スタイル**になる同根バグ（#48）。

調査の結果、ページネーション実装が2箇所に重複し、いずれもBootstrap依存していたため、共通化して同時に解消する。

| 実装 | 利用箇所 | 対応 |
|------|----------|:---:|
| `SupportWooCommerce::paginate()` | WooCommerceマイアカウントのサポート一覧 | 解消 |
| `hamethread_comment_links()` | コメント一覧（`UI/CommentForm`＝Bootstrap非依存文脈） | 解消 |

## 変更内容

- **共通ヘルパー** `hamethread_pagination_html()` を `functions.php` に新設。`paginate_links()` / `paginate_comments_links()` の `type => array` 出力を受け取り、`hamethread-pagination` 系の独自クラスへ変換する。重複していた2実装を集約。
  - 各リンクに `is-current` / `is-dots` / `is-prev` / `is-next` のstate修飾子を付与。
  - リンク要素のクラスのみ書き換え、内側のdashicon等は保持。
- `SupportWooCommerce::paginate()` と `hamethread_comment_links()` を共通ヘルパー呼び出しに置き換え。
- **SCSS**: `src/scss/_pagination.scss`（Bootstrap非依存の共通スタイル）を新設し、`hamethread.scss` と `hamethread-woocommerce.scss` の両方が `@use 'pagination'` で取り込む。
- **テスト**: `tests/TestPagination.php` を追加。マークアップ生成・stateクラス付与・Bootstrapクラス非混入・dashicon保持を検証。

## 検証

- `npm test` → OK (5 tests, 22 assertions)
- `composer lint`（PHPCS）/ `composer phpstan` / `npm run lint`（stylelint/eslint）すべてクリーン
- ビルド済みCSS（`assets/css/hamethread-woocommerce.css`）と実ヘルパー出力を組み合わせ、Chrome DevToolsで実機レンダリングを目視確認: 現在ページが濃色反転、`…`（dots）は枠線なしの非interactive、prev/next矢印も表示。

実ヘルパー出力例:
```html
<nav class="hamethread-pagination" aria-label="Demo"><ul class="hamethread-pagination-list">
  <li class="hamethread-pagination-item is-prev"><a class="hamethread-pagination-link" href="...">‹</a></li>
  <li class="hamethread-pagination-item"><a class="hamethread-pagination-link" href="...">1</a></li>
  <li class="hamethread-pagination-item is-current"><span aria-current="page" class="hamethread-pagination-link">3</span></li>
  ...
</ul></nav>
```

Closes #48

🤖 Generated with [Claude Code](https://claude.com/claude-code)