### PR TITLE
Plugin Check のエラー解消とローカルチェック基盤の追加 (#52)

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,7 +1,11 @@
 .browserslistrc
+.DS_Store
+.idea
+.phpunit.result.cache
 .claude
 .editorconfig
 .eslintrc
+.eslintrc.js
 .distignore
 .git
 .github

--- a/app/Hametuha/Thread/Command.php
+++ b/app/Hametuha/Thread/Command.php
@@ -42,11 +42,13 @@ class Command extends \WP_CLI_Command {
 		}, $posts ) );
 		$table->display();
 		\WP_CLI::line( '' );
-		\WP_CLI::success( sprintf(
-			__( '%1$s will be automatically closed %2$s', 'hamethread' ),
-			sprintf( _n( '%d thread', '%d threads', count( $posts ), 'hamethread' ), count( $posts ) ),
-			$diff ? sprintf( _n( 'in %d day', 'in %d days', $diff, 'hamethread' ), $diff ) : __( 'just now', 'hamethread' )
-		) );
+		// translators: %1$s is the number of threads, %2$s is the time until they close.
+		$close_message = __( '%1$s will be automatically closed %2$s', 'hamethread' );
+		// translators: %d is the number of threads.
+		$thread_count = sprintf( _n( '%d thread', '%d threads', count( $posts ), 'hamethread' ), count( $posts ) );
+		// translators: %d is the number of days until the thread closes.
+		$close_timing = $diff ? sprintf( _n( 'in %d day', 'in %d days', $diff, 'hamethread' ), $diff ) : __( 'just now', 'hamethread' );
+		\WP_CLI::success( sprintf( $close_message, $thread_count, $close_timing ) );
 	}
 
 	/**
@@ -58,6 +60,7 @@ class Command extends \WP_CLI_Command {
 	public function close( $args ) {
 		$diff   = isset( $args[0] ) ? $args[0] : 0;
 		$closed = AutoClose::get_instance()->do_cron( $diff );
+		// translators: %d is the number of closed threads.
 		\WP_CLI::success( sprintf( __( 'Automatically closed: %d', 'hamethread' ), $closed ) );
 	}
 

--- a/app/Hametuha/Thread/Hooks/AdminSetting.php
+++ b/app/Hametuha/Thread/Hooks/AdminSetting.php
@@ -73,7 +73,12 @@ class AdminSetting extends Singleton {
 			</p>
 			<?php
 		}, self::PAGE, self::SECTION, [ 'key' => self::OPTION_POST_TYPE ] );
-		register_setting( self::PAGE, self::OPTION_POST_TYPE );
+		register_setting( self::PAGE, self::OPTION_POST_TYPE, [
+			'type'              => 'array',
+			'sanitize_callback' => function ( $value ) {
+				return is_array( $value ) ? array_map( 'sanitize_key', $value ) : [];
+			},
+		] );
 	}
 
 	/**
@@ -92,7 +97,10 @@ class AdminSetting extends Singleton {
 			</p>
 			<?php
 		}, self::PAGE, self::SECTION, [ 'key' => self::OPTION_AUTO_CLOSE_DURATION ] );
-		register_setting( self::PAGE, self::OPTION_AUTO_CLOSE_DURATION );
+		register_setting( self::PAGE, self::OPTION_AUTO_CLOSE_DURATION, [
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+		] );
 		// Option for auto close prolong.
 		add_settings_field( self::OPTION_AUTO_CLOSE_PROLONG, __( 'Prolongation', 'hamethread' ), function ( $args ) {
 			$key          = $args['key'];
@@ -111,6 +119,9 @@ class AdminSetting extends Singleton {
 				);
 			}
 		}, self::PAGE, self::SECTION, [ 'key' => self::OPTION_AUTO_CLOSE_PROLONG ] );
-		register_setting( self::PAGE, self::OPTION_AUTO_CLOSE_PROLONG );
+		register_setting( self::PAGE, self::OPTION_AUTO_CLOSE_PROLONG, [
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+		] );
 	}
 }

--- a/app/Hametuha/Thread/Hooks/PostType.php
+++ b/app/Hametuha/Thread/Hooks/PostType.php
@@ -144,7 +144,7 @@ class PostType extends Singleton {
 		if ( ! $parent ) {
 			echo '<span style="color: lightgrey">---</span>';
 		} else {
-			echo edit_post_link( get_the_title( $parent ), '', '', $parent );
+			edit_post_link( get_the_title( $parent ), '', '', $parent );
 		}
 	}
 

--- a/app/Hametuha/Thread/Hooks/StructuredData.php
+++ b/app/Hametuha/Thread/Hooks/StructuredData.php
@@ -33,15 +33,12 @@ class StructuredData extends Singleton {
 		if ( ! $json ) {
 			return;
 		}
-		$json = json_encode( $json );
-		if ( ! $json ) {
+		$encoded = wp_json_encode( $json, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT );
+		if ( ! $encoded ) {
 			return;
 		}
-		echo <<<HTML
-<script type="application/ld+json">
-{$json}
-</script>
-HTML;
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- JSON encoded with JSON_HEX_* flags prevents </script> breakout; wrapper is a hardcoded literal.
+		echo '<script type="application/ld+json">' . $encoded . '</script>';
 	}
 
 	/**

--- a/app/Hametuha/Thread/Hooks/StructuredData.php
+++ b/app/Hametuha/Thread/Hooks/StructuredData.php
@@ -60,7 +60,7 @@ HTML;
 			'mainEntity' => [
 				'@type'       => 'Question',
 				'name'        => get_the_title( $post ),
-				'text'        => strip_tags( $post->post_content ),
+				'text'        => wp_strip_all_tags( $post->post_content ),
 				'answerCount' => get_comments_number( $post->ID ),
 				'upvoteCount' => hamethread_upvote_count( $post ),
 				'dateCreated' => mysql2date( \DateTime::ISO8601, $post->post_date_gmt ),

--- a/app/Hametuha/Thread/Hooks/SupportNotification.php
+++ b/app/Hametuha/Thread/Hooks/SupportNotification.php
@@ -52,7 +52,8 @@ class SupportNotification extends Singleton {
 		$subject = apply_filters(
 			'hamethread_notification_title',
 			sprintf(
-				__( '%s - A new comment is posted to your subscribing thread.', 'hamethread' ), // translator: %s is site title.
+				// translators: %s is the site title.
+				__( '%s - A new comment is posted to your subscribing thread.', 'hamethread' ),
 				get_bloginfo( 'name' )
 			),
 			$comment
@@ -177,11 +178,12 @@ To change notification setting, please go to thread page.
 			}
 		}
 		$subject = apply_filters( 'hamethread_auto_close_notification_title', sprintf(
-			__( '%1$s - Thread #%2$d is automatically closed.', 'hamethread' ), // translator: %1$s is site title, %2$d is post ID.
+			// translators: %1$s is the site title, %2$d is the post ID.
+			__( '%1$s - Thread #%2$d is automatically closed.', 'hamethread' ),
 			get_bloginfo( 'name' ),
 			$post->ID
 		), $post, $already_closed );
-		// translator: %1$s is user name, %2$s is date passed, %3$s is title, %4$s is URL.
+		// translators: %1$s is the user name, %2$s is the date passed, %3$s is the title, %4$s is the URL.
 		$body     = __( 'Dear %1$s,
 
 Since %2$s been passed from last comment,
@@ -194,8 +196,9 @@ URL: %4$s
 		$title    = get_the_title( $post );
 		$url      = get_permalink( $post );
 		$duration = AutoClose::get_instance()->get_duration( $post->ID );
-		$passed   = sprintf( _n( '%d day has', '%d days have', $duration, 'hamethread' ), $duration );
-		$body     = sprintf( $body, '-name-', $passed, $title, $url );
+		// translators: %d is the number of days passed.
+		$passed = sprintf( _n( '%d day has', '%d days have', $duration, 'hamethread' ), $duration );
+		$body   = sprintf( $body, '-name-', $passed, $title, $url );
 		if ( function_exists( 'hamail_simple_mail' ) ) {
 			hamail_simple_mail(
 				array_map(

--- a/app/Hametuha/Thread/Pattern/RushDetector.php
+++ b/app/Hametuha/Thread/Pattern/RushDetector.php
@@ -31,6 +31,7 @@ class RushDetector {
 	 */
 	public static function rushing_message( $user_id = 0 ) {
 		$condition = self::get_rushing_condition( $user_id );
+		// translators: %1$d is the comment limit, %2$d is the time window in minutes.
 		return sprintf( __( 'You posted more than %1$d comments in %2$d minutes. Please be patient.', 'hamethread' ), $condition['limit'], $condition['minutes'] );
 	}
 

--- a/app/Hametuha/Thread/Rest/RestCommentNew.php
+++ b/app/Hametuha/Thread/Rest/RestCommentNew.php
@@ -85,6 +85,7 @@ class RestCommentNew extends RestBase {
 		$parent_comment = $reply_to ? get_comment( $reply_to ) : null;
 		$args           = [
 			'title'          => $reply_to
+				// translators: %s is the comment author name.
 				? esc_html( sprintf( __( 'Reply to %s', 'hamethread' ), get_comment_author( $reply_to ) ) )
 				: esc_html__( 'Post comment', 'hamethread' ),
 			'post'           => get_post( $post_id ),

--- a/app/Hametuha/Thread/Rest/RestThread.php
+++ b/app/Hametuha/Thread/Rest/RestThread.php
@@ -134,8 +134,10 @@ class RestThread extends RestBase {
 			return $post_id;
 		}
 		if ( 'private' === $new_status ) {
+			// translators: %s is the thread title.
 			$message = __( 'Thread %s has been successfully private.', 'hamethread' );
 		} else {
+			// translators: %s is the thread title.
 			$message = __( 'Thread %s has been successfully published.', 'hamethread' );
 		}
 		return [

--- a/app/Hametuha/Thread/UI/CommentForm.php
+++ b/app/Hametuha/Thread/UI/CommentForm.php
@@ -84,6 +84,7 @@ class CommentForm extends AbstractUI {
 			$html .= "</{$tag}>";
 		}
 		if ( $echo ) {
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe HTML composed from comment_class() and the escaped comment-loop template part.
 			echo $html;
 		}
 		return $html;

--- a/bin/pcp-excludes.sh
+++ b/bin/pcp-excludes.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+#
+# Plugin Check (PCP) の除外フラグを .distignore から生成する。
+# .distignore を「配布されないもの = チェックしないもの」の単一の真実とし、
+# 各エントリをファイル/ディレクトリに振り分けて以下を出力する:
+#
+#   --exclude-directories=dir1,dir2 --exclude-files=path/to/file1,file2
+#
+# 使い方: bash bin/pcp-excludes.sh [path-to-.distignore]
+#
+set -euo pipefail
+
+distignore="${1:-.distignore}"
+[ -f "$distignore" ] || { echo ""; exit 0; }
+
+dirs=()
+files=()
+
+while IFS= read -r raw || [ -n "$raw" ]; do
+	line="${raw%%#*}"                          # コメント除去
+	line="${line#"${line%%[![:space:]]*}"}"    # 前方の空白除去
+	line="${line%"${line##*[![:space:]]}"}"    # 後方の空白除去
+	[ -z "$line" ] && continue
+
+	path="${line#/}"                           # 先頭スラッシュ除去（root相対）
+	if [ -d "$path" ]; then
+		dirs+=("$(basename "$path")")          # PCPはディレクトリ名で一致
+	elif [ -f "$path" ]; then
+		files+=("$path")                       # ファイルはroot相対パス
+	else
+		# 実在しないエントリは末尾/・拡張子で推測（不在なら除外対象が無く無害）
+		case "$line" in
+			*/) dirs+=("$(basename "$path")") ;;
+			*.*) files+=("$path") ;;
+			*) dirs+=("$(basename "$path")") ;;
+		esac
+	fi
+done < "$distignore"
+
+args=""
+[ ${#dirs[@]} -gt 0 ]  && args="--exclude-directories=$(IFS=,; echo "${dirs[*]}")"
+[ ${#files[@]} -gt 0 ] && args="$args --exclude-files=$(IFS=,; echo "${files[*]}")"
+echo "$args"

--- a/functions.php
+++ b/functions.php
@@ -167,9 +167,7 @@ function hamethread_recently_commented( $offset = 7, $post = null ) {
  */
 function hamethread_get_author_thread_count( $user_id ) {
 	global $wpdb;
-	$sql = <<<EOS
-		SELECT COUNT(ID) FROM {$wpdb->posts} WHERE post_author = %d AND post_type = %s AND post_status = 'publish'
-EOS;
+	$sql = "SELECT COUNT(ID) FROM {$wpdb->posts} WHERE post_author = %d AND post_type = %s AND post_status = 'publish'";
 	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	return (int) $wpdb->get_var( $wpdb->prepare( $sql, $user_id, hamethread_post_type() ) );
 }
@@ -184,11 +182,9 @@ EOS;
 function hamethread_get_latest_comment_date( $post = null ) {
 	global $wpdb;
 	$post = get_post( $post );
-	$sql  = <<<EOS
-		SELECT comment_date FROM {$wpdb->comments}
+	$sql  = "SELECT comment_date FROM {$wpdb->comments}
 		WHERE comment_post_ID = %d
-		LIMIT 1
-EOS;
+		LIMIT 1";
 	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	return $wpdb->get_var( $wpdb->prepare( $sql, $post->ID ) );
 }
@@ -202,12 +198,10 @@ EOS;
  */
 function hamethread_get_author_response_count( $user_id ) {
 	global $wpdb;
-	$sql = <<<EOS
-		SELECT COUNT(comment_ID) FROM {$wpdb->comments} AS c
+	$sql = "SELECT COUNT(comment_ID) FROM {$wpdb->comments} AS c
 		INNER JOIN {$wpdb->posts} AS p
 		ON c.comment_post_ID = p.ID
-		WHERE p.post_type = 'thread' AND c.user_id = %d
-EOS;
+		WHERE p.post_type = 'thread' AND c.user_id = %d";
 	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	return (int) $wpdb->get_var( $wpdb->prepare( $sql, $user_id ) );
 }
@@ -517,14 +511,12 @@ function hamethread_upvote_count( $post = null ) {
 	if ( ! $post ) {
 		return 0;
 	}
-	$query = <<<SQL
-		SELECT COUNT( cm.meta_id )
+	$query = "SELECT COUNT( cm.meta_id )
 		FROM {$wpdb->commentmeta} AS cm
 		LEFT JOIN {$wpdb->comments} AS c
 		ON cm.comment_id = c.comment_ID
 		WHERE cm.meta_key = '_user_upvote'
-		  AND c.comment_post_ID = %d
-SQL;
+		  AND c.comment_post_ID = %d";
 	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	return (int) $wpdb->get_var( $wpdb->prepare( $query, $post->ID ) );
 }
@@ -538,11 +530,9 @@ SQL;
 function hamethread_comment_upvoted_count( $comment = null ) {
 	$comment = get_comment( $comment );
 	global $wpdb;
-	$query = <<<SQL
-		SELECT COUNT( meta_id ) FROM {$wpdb->commentmeta}
+	$query = "SELECT COUNT( meta_id ) FROM {$wpdb->commentmeta}
 		WHERE comment_id = %d
-		  AND meta_key   = '_user_upvote'
-SQL;
+		  AND meta_key   = '_user_upvote'";
 	// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 	return (int) $wpdb->get_var( $wpdb->prepare( $query, $comment->comment_ID ) );
 }

--- a/functions.php
+++ b/functions.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'ABSPATH' ) || die();
 /**
  * Global functions
  *

--- a/hamethread.php
+++ b/hamethread.php
@@ -54,7 +54,7 @@ function hamethread_init() {
  */
 function hamethread_version_error() {
 	// translators: %1$s required PHP version, %2$s current PHP version.
-	printf( '<div class="error"><p>%s</p></div>', sprintf( esc_html__( 'HameThread requires PHP %1$s, but your PHP version is %2$s. Please consider upgrade.', 'hamethread' ), '7.4', phpversion() ) );
+	echo wp_kses_post( sprintf( '<div class="error"><p>%s</p></div>', sprintf( esc_html__( 'HameThread requires PHP %1$s, but your PHP version is %2$s. Please consider upgrade.', 'hamethread' ), '7.4', phpversion() ) ) );
 }
 
 /**

--- a/includes/best-answer.php
+++ b/includes/best-answer.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'ABSPATH' ) || die();
 /**
  * Best answer related functions.
  *

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"log:tail": "wp-env run cli tail -f /var/www/html/wp-content/debug.log",
 		"cli:test": "wp-env run tests-cli wp",
 		"test": "RESULT=${PWD##*/} && wp-env run tests-cli ./wp-content/plugins/$RESULT/vendor/bin/phpunit -c ./wp-content/plugins/$RESULT/phpunit.xml.dist",
-		"check": "RESULT=${PWD##*/} && wp-env run cli wp plugin check wp-content/plugins/$RESULT --require=./wp-content/plugins/plugin-check/cli.php --exclude-directories=.git,vendor,tests,node_modules,wordpress",
+		"check": "RESULT=${PWD##*/} && wp-env run cli wp plugin check wp-content/plugins/$RESULT --require=./wp-content/plugins/plugin-check/cli.php $(bash bin/pcp-excludes.sh)",
 		"build": "npm run build:css && npm run build:js && npm run dump",
 		"dump": "grab-deps dump assets",
 		"build:js": "grab-deps js src/js assets/js js",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
 		"log:tail": "wp-env run cli tail -f /var/www/html/wp-content/debug.log",
 		"cli:test": "wp-env run tests-cli wp",
 		"test": "RESULT=${PWD##*/} && wp-env run tests-cli ./wp-content/plugins/$RESULT/vendor/bin/phpunit -c ./wp-content/plugins/$RESULT/phpunit.xml.dist",
+		"check": "RESULT=${PWD##*/} && wp-env run cli wp plugin check wp-content/plugins/$RESULT --require=./wp-content/plugins/plugin-check/cli.php --exclude-directories=.git,vendor,tests,node_modules,wordpress",
 		"build": "npm run build:css && npm run build:js && npm run dump",
 		"dump": "grab-deps dump assets",
 		"build:js": "grab-deps js src/js assets/js js",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -121,12 +121,6 @@ parameters:
 			path: app/Hametuha/Thread/Hooks/BestAnswer.php
 
 		-
-			message: '#^Result of function edit_post_link \(void\) is used\.$#'
-			identifier: function.void
-			count: 1
-			path: app/Hametuha/Thread/Hooks/PostType.php
-
-		-
 			message: '#^Unreachable statement \- code above always terminates\.$#'
 			identifier: deadCode.unreachable
 			count: 3

--- a/template-parts/button-comment-post.php
+++ b/template-parts/button-comment-post.php
@@ -1,3 +1,4 @@
+<?php defined( 'ABSPATH' ) || die(); ?>
 <div class="hamethread-post-comment">
 	<?php if ( hamethread_current_user_can_comment() ) : ?>
 	<button class="button hamethread-post-button" data-hamethread="comment" data-end-point="<?php printf( 'comment/%d/new', get_the_ID() ); ?>">

--- a/template-parts/button-comment-post.php
+++ b/template-parts/button-comment-post.php
@@ -7,7 +7,10 @@
 	</button>
 	<?php else : ?>
 	<div class="hamethread-alert hamethread-alert-warning">
-		<?php echo wp_kses_post( sprintf( __( 'Please <a href="%s">log in</a> to post a comment.', 'hamethread' ), hamethread_login_url( get_permalink() ) ) ); ?>
+		<?php
+		// translators: %s is the login URL.
+		echo wp_kses_post( sprintf( __( 'Please <a href="%s">log in</a> to post a comment.', 'hamethread' ), hamethread_login_url( get_permalink() ) ) );
+		?>
 	</div>
 	<?php endif; ?>
 </div>

--- a/template-parts/button-comment-post.php
+++ b/template-parts/button-comment-post.php
@@ -1,8 +1,11 @@
 <?php defined( 'ABSPATH' ) || die(); ?>
 <div class="hamethread-post-comment">
 	<?php if ( hamethread_current_user_can_comment() ) : ?>
-	<button class="button hamethread-post-button" data-hamethread="comment" data-end-point="<?php printf( 'comment/%d/new', get_the_ID() ); ?>">
-		<?php echo hamethread_icon( 'plus-alt' ); ?>
+	<button class="button hamethread-post-button" data-hamethread="comment" data-end-point="<?php echo esc_attr( sprintf( 'comment/%d/new', get_the_ID() ) ); ?>">
+		<?php
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe HTML escaped in hamethread_icon().
+		echo hamethread_icon( 'plus-alt' );
+		?>
 		<?php esc_html_e( 'Post Comment', 'hamethread' ); ?>
 	</button>
 	<?php else : ?>

--- a/template-parts/button-thread-controller.php
+++ b/template-parts/button-thread-controller.php
@@ -34,12 +34,12 @@ if ( $can_edit ) {
 if ( $can_archive ) {
 	?>
 	<li class="hamethread-controller-item">
-		<a href="<?php echo rest_url( 'hamethread/v1/thread/' . $post->ID ); ?>" rel="nofollow" data-hamethread="<?php echo esc_attr( $key ); ?>" data-post-id="<?php echo esc_attr( $post->ID ); ?>">
+		<a href="<?php echo esc_url( rest_url( 'hamethread/v1/thread/' . $post->ID ) ); ?>" rel="nofollow" data-hamethread="<?php echo esc_attr( $key ); ?>" data-post-id="<?php echo esc_attr( $post->ID ); ?>">
 			<?php echo esc_html( $label ); ?>
 		</a>
 	</li>
 	<li class="hamethread-controller-item">
-		<a href="<?php echo rest_url( 'hamethread/v1/thread/lock/' . $post->ID ); ?>" rel="nofollow" data-hamethread="<?php echo comments_open( $post ) ? 'lock' : 'reopen'; ?>">
+		<a href="<?php echo esc_url( rest_url( 'hamethread/v1/thread/lock/' . $post->ID ) ); ?>" rel="nofollow" data-hamethread="<?php echo comments_open( $post ) ? 'lock' : 'reopen'; ?>">
 			<?php echo esc_html( $lock_action ); ?>
 		</a>
 	</li>
@@ -57,12 +57,16 @@ if ( ! $lists ) {
 <div class="hamethread-controller">
 	<div class="hamethread-controller-dropdown">
 		<button class="hamethread-controller-toggle" type="button" aria-expanded="false" aria-haspopup="true">
-			<?php echo hamethread_icon( 'cog' ); ?>
+			<?php
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe HTML escaped in hamethread_icon().
+				echo hamethread_icon( 'cog' );
+			?>
 			<span class="screen-reader-text"><?php esc_html_e( 'Thread actions', 'hamethread' ); ?></span>
 		</button>
 		<ul class="hamethread-controller-menu">
 			<?php
 			foreach ( $lists as $list ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Composed list-item HTML escaped at source above (esc_url/esc_attr/esc_html).
 				echo $list;
 			}
 			?>

--- a/template-parts/button-thread-controller.php
+++ b/template-parts/button-thread-controller.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'ABSPATH' ) || die();
 if ( ! $can_edit && ! $can_archive ) {
 	return;
 }

--- a/template-parts/button-thread.php
+++ b/template-parts/button-thread.php
@@ -20,6 +20,9 @@ $attr = wp_parse_args( $attr, [
 </button>
 <?php else : ?>
 <div class="hamethread-alert hamethread-alert-warning">
-	<?php echo wp_kses_post( sprintf( __( 'To start thread, please <a rel="nofollow" href="%s">log in</a>.', 'hamethread' ), hamethread_login_url( isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '' ) ) ); ?>
+	<?php
+	// translators: %s is the login URL.
+	echo wp_kses_post( sprintf( __( 'To start thread, please <a rel="nofollow" href="%s">log in</a>.', 'hamethread' ), hamethread_login_url( isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : '' ) ) );
+	?>
 </div>
 <?php endif; ?>

--- a/template-parts/button-thread.php
+++ b/template-parts/button-thread.php
@@ -14,7 +14,7 @@ $attr = wp_parse_args( $attr, [
 ?>
 
 <?php if ( hamethread_user_can_start() ) : ?>
-<button data-hamethread="create" class="<?php echo esc_attr( $attr['class'] ); ?>" data-parent="<?php printf( '%d', $parent ); ?>" data-private="<?php echo (int) $private; ?>">
+<button data-hamethread="create" class="<?php echo esc_attr( $attr['class'] ); ?>" data-parent="<?php echo (int) $parent; ?>" data-private="<?php echo (int) $private; ?>">
 	<?php echo wp_kses_post( $attr['prefix'] ); ?>
 	<?php echo esc_html( $label ); ?>
 </button>

--- a/template-parts/button-thread.php
+++ b/template-parts/button-thread.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'ABSPATH' ) || die();
 /*
  * Thread buttons.
  */

--- a/template-parts/comment-loop.php
+++ b/template-parts/comment-loop.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'ABSPATH' ) || die();
 /**
  * Comment loop for hamethread.
  *

--- a/template-parts/comment-loop.php
+++ b/template-parts/comment-loop.php
@@ -11,18 +11,21 @@ defined( 'ABSPATH' ) || die();
 	<div class="hamethread-controller">
 		<div class="hamethread-controller-dropdown">
 			<button class="hamethread-controller-toggle" type="button" aria-expanded="false" aria-haspopup="true">
-				<?php echo hamethread_icon( 'cog' ); ?>
+				<?php
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe HTML escaped in hamethread_icon().
+					echo hamethread_icon( 'cog' );
+				?>
 				<span class="screen-reader-text"><?php esc_html_e( 'Comment actions', 'hamethread' ); ?></span>
 			</button>
 			<ul class="hamethread-controller-menu">
 				<li class="hamethread-controller-item">
-					<a href="<?php printf( 'comment/%d/%d', $comment->comment_post_ID, $comment->comment_ID ); ?>"
+					<a href="<?php echo esc_url( sprintf( 'comment/%d/%d', $comment->comment_post_ID, $comment->comment_ID ) ); ?>"
 						data-hamethread="comment-edit" rel="nofollow">
 						<?php esc_html_e( 'Edit', 'hamethread' ); ?>
 					</a>
 				</li>
 				<li class="hamethread-controller-item">
-					<a href="<?php printf( 'comment/%d/%d', $comment->comment_post_ID, $comment->comment_ID ); ?>"
+					<a href="<?php echo esc_url( sprintf( 'comment/%d/%d', $comment->comment_post_ID, $comment->comment_ID ) ); ?>"
 						rel="nofollow" data-hamethread="comment-delete">
 						<?php esc_html_e( 'Delete', 'hamethread' ); ?>
 					</a>
@@ -38,7 +41,13 @@ defined( 'ABSPATH' ) || die();
 	<div class="hamethread-comment-body">
 		<header class="hamethread-comment-header">
 			<span class="hamethread-comment-author"><?php comment_author( $comment ); ?></span>
-			<span class="<?php echo hamethread_commentor_label_class( $comment, 'hamethread-comment-role' ); ?>"><?php echo hamethread_commentor_label( $comment ); ?></span>
+			<?php $hamethread_label_class = hamethread_commentor_label_class( $comment, 'hamethread-comment-role' ); ?>
+			<span class="<?php echo $hamethread_label_class; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Already escaped via esc_attr() in hamethread_commentor_label_class(). ?>">
+				<?php
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe HTML escaped in hamethread_commentor_label().
+				echo hamethread_commentor_label( $comment );
+				?>
+			</span>
 			<span class="hamethread-comment-date">
 				<?php comment_date( '', $comment ); ?>
 				<?php if ( hamethread_is_edited( $comment ) ) : ?>
@@ -49,7 +58,11 @@ defined( 'ABSPATH' ) || die();
 		<div class="hamethread-comment-content">
 			<?php if ( hamethread_is_best_answer( $comment ) ) : ?>
 				<p class="hamethread-comment-best-answer">
-					<?php echo hamethread_icon( 'star' ); ?> <strong><?php esc_html_e( 'Best Answer', 'hamethread' ); ?></strong>
+					<?php
+						// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe HTML escaped in hamethread_icon().
+						echo hamethread_icon( 'star' );
+					?>
+						<strong><?php esc_html_e( 'Best Answer', 'hamethread' ); ?></strong>
 				</p>
 			<?php endif; ?>
 			<?php comment_text(); ?>
@@ -57,6 +70,7 @@ defined( 'ABSPATH' ) || die();
 		<footer class="hamethread-comment-actions">
 			<?php
 			foreach ( hamethread_comment_actions( $comment ) as $action ) {
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe HTML (incl. data-* attrs) escaped at source in hamethread_comment_actions().
 				echo $action;
 			}
 			?>

--- a/template-parts/comment-watcher.php
+++ b/template-parts/comment-watcher.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'ABSPATH' ) || die();
 /**
  * Comment watcher list.
  */

--- a/template-parts/comment-watcher.php
+++ b/template-parts/comment-watcher.php
@@ -14,7 +14,10 @@ defined( 'ABSPATH' ) || die();
 		</div>
 	<?php else : ?>
 		<p class="hamethread-text-muted">
-			<?php echo wp_kses_post( sprintf( __( 'Please <a href="%s" rel="nofollow">login</a> to follow this thread.', 'hamethread' ), hamethread_login_url( get_permalink() ) ) ); ?>
+			<?php
+			// translators: %s is the login URL.
+			echo wp_kses_post( sprintf( __( 'Please <a href="%s" rel="nofollow">login</a> to follow this thread.', 'hamethread' ), hamethread_login_url( get_permalink() ) ) );
+			?>
 		</p>
 	<?php endif; ?>
 
@@ -24,7 +27,10 @@ defined( 'ABSPATH' ) || die();
 		?>
 		<div class="hamethread-watchers-list">
 			<p class="hamethread-text-muted">
-				<?php echo esc_html( sprintf( _n( '%d people following.', '%d people following.', count( $followers ), 'hamethread' ), count( $followers ) ) ); ?>
+				<?php
+				// translators: %d is the number of people following the thread.
+				echo esc_html( sprintf( _n( '%d people following.', '%d people following.', count( $followers ), 'hamethread' ), count( $followers ) ) );
+				?>
 			</p>
 			<?php foreach ( $followers as $user ) : ?>
 				<div class="hamethread-watchers-item">

--- a/template-parts/comments-no.php
+++ b/template-parts/comments-no.php
@@ -1,3 +1,4 @@
+<?php defined( 'ABSPATH' ) || die(); ?>
 <div class="hamethread-alert hamethread-alert-muted hamethread-nocomment">
 	<?php echo esc_html( sprintf( __( 'This %s has no comment.', 'hamethread' ), get_post_type_object( get_post_type() )->label ) ); ?>
 </div>

--- a/template-parts/comments-no.php
+++ b/template-parts/comments-no.php
@@ -1,4 +1,7 @@
 <?php defined( 'ABSPATH' ) || die(); ?>
 <div class="hamethread-alert hamethread-alert-muted hamethread-nocomment">
-	<?php echo esc_html( sprintf( __( 'This %s has no comment.', 'hamethread' ), get_post_type_object( get_post_type() )->label ) ); ?>
+	<?php
+	// translators: %s is the post type label.
+	echo esc_html( sprintf( __( 'This %s has no comment.', 'hamethread' ), get_post_type_object( get_post_type() )->label ) );
+	?>
 </div>

--- a/template-parts/comments.php
+++ b/template-parts/comments.php
@@ -1,4 +1,6 @@
-<?php if ( hamethread_user_can_comment() && comments_open() ) : ?>
+<?php
+defined( 'ABSPATH' ) || die();
+if ( hamethread_user_can_comment() && comments_open() ) : ?>
 	<?php hamethread_template( 'button-comment-post' ); ?>
 <?php else : ?>
 	<?php hamethread_template( 'form-nocap' ); ?>

--- a/template-parts/comments.php
+++ b/template-parts/comments.php
@@ -15,7 +15,10 @@ if ( hamethread_user_can_comment() && comments_open() ) : ?>
 		] );
 		?>
 
-		<?php echo hamethread_comment_links(); ?>
+		<?php
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe HTML escaped in hamethread_pagination_html() (via hamethread_comment_links()).
+		echo hamethread_comment_links();
+		?>
 	<?php endif; ?>
 </ul>
 

--- a/template-parts/form-comment.php
+++ b/template-parts/form-comment.php
@@ -17,7 +17,10 @@
 				</time>
 			</cite>
 			<div class="hamethread-form-quote-content">
-				<?php echo wpautop( esc_html( $parent_comment->comment_content ) ); ?>
+				<?php
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Content escaped via esc_html() before wpautop() wraps it in safe <p> tags.
+				echo wpautop( esc_html( $parent_comment->comment_content ) );
+				?>
 			</div>
 		</blockquote>
 		<?php endif; ?>

--- a/template-parts/form-comment.php
+++ b/template-parts/form-comment.php
@@ -1,3 +1,4 @@
+<?php defined( 'ABSPATH' ) || die(); ?>
 <form class="hamethread-form" id="hamethread-comment" method="post" action="<?php echo esc_attr( $action ); ?>">
 
 	<div class="hamethread-form-container">

--- a/template-parts/form-nocap.php
+++ b/template-parts/form-nocap.php
@@ -1,3 +1,4 @@
+<?php defined( 'ABSPATH' ) || die(); ?>
 <div class="hamethread-alert hamethread-alert-muted hamethread-nocap" style="text-align: center;">
 	<?php if ( comments_open() ) : ?>
 		<?php printf( wpautop( __( 'You have no permission to comment. Please <a href="%s">log in</a> and continue.', 'hamethread' ) ), hamethread_login_url( get_permalink() ) ); ?>

--- a/template-parts/form-nocap.php
+++ b/template-parts/form-nocap.php
@@ -3,7 +3,7 @@
 	<?php if ( comments_open() ) : ?>
 		<?php
 		// translators: %s is the login URL.
-		printf( wpautop( __( 'You have no permission to comment. Please <a href="%s">log in</a> and continue.', 'hamethread' ) ), hamethread_login_url( get_permalink() ) );
+		echo wp_kses_post( wpautop( sprintf( __( 'You have no permission to comment. Please <a href="%s">log in</a> and continue.', 'hamethread' ), esc_url( hamethread_login_url( get_permalink() ) ) ) ) );
 		?>
 	<?php else : ?>
 		<p><?php esc_html_e( 'Comments are closed.', 'hamethread' ); ?></p>

--- a/template-parts/form-nocap.php
+++ b/template-parts/form-nocap.php
@@ -1,7 +1,10 @@
 <?php defined( 'ABSPATH' ) || die(); ?>
 <div class="hamethread-alert hamethread-alert-muted hamethread-nocap" style="text-align: center;">
 	<?php if ( comments_open() ) : ?>
-		<?php printf( wpautop( __( 'You have no permission to comment. Please <a href="%s">log in</a> and continue.', 'hamethread' ) ), hamethread_login_url( get_permalink() ) ); ?>
+		<?php
+		// translators: %s is the login URL.
+		printf( wpautop( __( 'You have no permission to comment. Please <a href="%s">log in</a> and continue.', 'hamethread' ) ), hamethread_login_url( get_permalink() ) );
+		?>
 	<?php else : ?>
 		<p><?php esc_html_e( 'Comments are closed.', 'hamethread' ); ?></p>
 	<?php endif; ?>

--- a/template-parts/form-thread.php
+++ b/template-parts/form-thread.php
@@ -57,7 +57,10 @@ defined( 'ABSPATH' ) || die();
 			</label>
 			<small id="is_private_description" class="hamethread-form-help">
 				<?php if ( $post ) : ?>
-					<?php echo esc_html( sprintf( __( 'Author of %s and invited people can see private thread.', 'hamethread' ), get_the_title( $post ) ) ); ?>
+					<?php
+					// translators: %s is the thread title.
+					echo esc_html( sprintf( __( 'Author of %s and invited people can see private thread.', 'hamethread' ), get_the_title( $post ) ) );
+					?>
 				<?php else : ?>
 					<?php esc_html_e( 'Only invited people can see private thread.', 'hamethread' ); ?>
 				<?php endif; ?>

--- a/template-parts/form-thread.php
+++ b/template-parts/form-thread.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'ABSPATH' ) || die();
 /**
  * Form to create thread.
  *

--- a/template-parts/woocommerce-my-account.php
+++ b/template-parts/woocommerce-my-account.php
@@ -11,7 +11,7 @@ if ( $query->have_posts() ) :
 <p class="hamethread-text-muted">
 	<?php
 	// translators: %s is the number of threads (e.g. "3 threads").
-	printf( __( 'You have %s.', 'hamethread' ), $thread_count );
+	echo esc_html( sprintf( __( 'You have %s.', 'hamethread' ), $thread_count ) );
 	?>
 </p>
 
@@ -24,20 +24,34 @@ if ( $query->have_posts() ) :
 		<div class="hamethread-my-threads-header">
 			<h5 class="hamethread-my-threads-title">
 				<?php if ( 'private' === get_post_status() ) : ?>
-					<?php echo hamethread_icon( 'lock' ); ?>
+					<?php
+					// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe HTML escaped in hamethread_icon().
+					echo hamethread_icon( 'lock' );
+					?>
 				<?php endif; ?>
 				<a href="<?php the_permalink(); ?>"><?php the_title(); ?></a>
 			</h5>
 			<small class="hamethread-my-threads-date"><?php the_time( get_option( 'date_format' ) ); ?></small>
 		</div>
 		<p class="hamethread-my-threads-meta">
-			<?php echo hamethread_icon( 'admin-comments' ); ?> <?php comments_number(); ?>
+			<?php
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe HTML escaped in hamethread_icon().
+			echo hamethread_icon( 'admin-comments' );
+			?>
+			<?php comments_number(); ?>
 			<?php if ( hamethread_is_resolved() ) : ?>
-				<?php echo hamethread_icon( 'yes-alt' ); ?> <?php esc_html_e( 'Resolved', 'hamethread' ); ?>
+				<?php
+				// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe HTML escaped in hamethread_icon().
+				echo hamethread_icon( 'yes-alt' );
+				?>
+				<?php esc_html_e( 'Resolved', 'hamethread' ); ?>
 			<?php endif; ?>
 		</p>
 		<small class="hamethread-my-threads-updated">
-			<?php echo hamethread_icon( 'clock' ); ?>
+			<?php
+			// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Safe HTML escaped in hamethread_icon().
+			echo hamethread_icon( 'clock' );
+			?>
 			<?php
 				esc_html_e( 'Last Updated: ', 'hamethread' );
 				echo esc_html( hamethread_last_commented() );
@@ -49,7 +63,10 @@ if ( $query->have_posts() ) :
 	wp_reset_postdata();
 	?>
 </ul>
-	<?php echo apply_filters( 'hamethread_pagination', '', $query ); ?>
+	<?php
+	// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped -- Trusted pagination HTML provided via the hamethread_pagination filter.
+	echo apply_filters( 'hamethread_pagination', '', $query );
+	?>
 	<?php
 	// Query has no post.
 else :

--- a/template-parts/woocommerce-my-account.php
+++ b/template-parts/woocommerce-my-account.php
@@ -1,4 +1,5 @@
 <?php
+defined( 'ABSPATH' ) || die();
 /** @var WP_Query $query */
 if ( $query->have_posts() ) :
 	?>

--- a/template-parts/woocommerce-my-account.php
+++ b/template-parts/woocommerce-my-account.php
@@ -4,7 +4,16 @@ defined( 'ABSPATH' ) || die();
 if ( $query->have_posts() ) :
 	?>
 
-<p class="hamethread-text-muted"><?php printf( __( 'You have %s.', 'hamethread' ), sprintf( _nx( '%d thread', '%d threads', $query->found_posts, 'owning-thread', 'hamethread' ), $query->found_posts ) ); ?></p>
+	<?php
+	// translators: %d is the number of threads the user owns.
+	$thread_count = sprintf( _nx( '%d thread', '%d threads', $query->found_posts, 'owning-thread', 'hamethread' ), $query->found_posts );
+	?>
+<p class="hamethread-text-muted">
+	<?php
+	// translators: %s is the number of threads (e.g. "3 threads").
+	printf( __( 'You have %s.', 'hamethread' ), $thread_count );
+	?>
+</p>
 
 <ul class="hamethread-my-threads">
 	<?php


### PR DESCRIPTION
## 概要

#52 の一環として、**WordPress Plugin Check (PCP) のエラーを解消**し、ローカルでPCPを回す仕組み (`npm run check`) を追加した。wordpress.org 公開レディネス (#50) の中核。

> このPRは #52 のうち「コード修正＋ローカルチェック基盤」を対象とする。**CI統合と `tarosky/workflows` への抽出はリリースサイクル確認後に別PR**で行う(#52 はオープンのまま)。

## やったこと

| カテゴリ | 件数 | 対応 |
|----------|------|------|
| ABSPATH 直アクセスガード欠落 | 14 | テンプレート/関数ファイルにガード追加 |
| 配布ゴミの混入 (`hidden_files` 等) | ~17 | **`.distignore` 駆動の除外**に統一 + 配布漏れ修正 |
| i18n translators コメント欠落 | 21 | `// translators:` 追加(既存の単数 `translator:` も修正) |
| `register_setting` の sanitize 欠落 | 3 | `sanitize_callback` 追加 |
| `strip_tags` | 1 | `wp_strip_all_tags` に置換 |
| 出力エスケープ漏れ | 30 | escape-at-source + 検証済み `phpcs:ignore`、値は `esc_*` |
| heredoc 構文 (SQL / JSON-LD) | 7 | 通常文字列化、JSON-LD は hex フラグで安全化 |

結果: ローカルPCPは **`no_plugin_readme` 1件を除いて完全グリーン**。これは readme.txt がビルド生成物のためソースに無いだけで、ビルド成果物では解消する(readme 内容整備は #51)。

## 注目ポイント

- **実バグ修正**: `.distignore` に `.idea/` `.DS_Store` `.eslintrc.js` `.phpunit.result.cache` が無く、**配布zipに混入していた**(`.idea` はローカルパス漏洩)。`.distignore` を単一の真実とし、`bin/pcp-excludes.sh` が各エントリをファイル/ディレクトリに振り分けて PCP の `--exclude-files` / `--exclude-directories` を生成する。「チェックがクリーン ⟺ `.distignore` が完全」という同値が成立する。
- **エスケープ方針**: ヘルパ関数 (`hamethread_icon` 等) は関数内でエスケープ (escape-at-source) し、`data-*` 属性を持つ `$action` は `wp_kses_post` で壊れるため `phpcs:ignore` を理由付きで使用。全 ignore は対象関数が実際にエスケープしていることをレビュー済み。

## 確認

- ✅ PHPCS (WPCS) — pre-commit で各コミット通過
- ✅ PHPStan — クリーン(コード修正に伴い陳腐化した baseline エントリも削除)
- ✅ PCP(ローカル)— エラーは `no_plugin_readme` のみ
- ⏳ PHPUnit — **このPRのCIで確認**(ローカルwp-env都合のため)

Refs #52, #50
