### PR TITLE
[検証] ビルド成果物への Plugin Check CI (#52)

### DIFF
--- a/.github/workflows/plugin-check.yml
+++ b/.github/workflows/plugin-check.yml
@@ -1,0 +1,44 @@
+name: Plugin Check
+
+on:
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+jobs:
+  plugin-check:
+    name: WordPress Plugin Check (build artifact)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '7.4'
+          tools: composer
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      # vendor/autoload.php must exist in the artifact because Plugin Check
+      # activates the plugin (which loads composer's autoloader).
+      - name: Install Composer dependencies (production only)
+        run: composer install --no-dev --no-progress
+
+      # readme.txt is generated at build time from README.md (same tool as bin/build.sh).
+      # Without it, Plugin Check reports `no_plugin_readme`.
+      - name: Generate readme.txt
+        run: curl -sL https://raw.githubusercontent.com/fumikito/wp-readme/master/wp-readme.php | php
+
+      # Assemble the shippable artifact exactly as the release build does:
+      # everything except what .distignore excludes (dev files, tests, etc.).
+      - name: Assemble shippable artifact
+        run: |
+          mkdir -p dist/hamethread
+          rsync -a --exclude-from=.distignore --exclude='dist' ./ dist/hamethread/
+
+      - name: Run Plugin Check on the artifact
+        uses: WordPress/plugin-check-action@v1.1.7
+        with:
+          build-dir: ./dist/hamethread

--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 
 Contributors: hametuha, Takahashi_Fumiki  
 Tags: faq,thread,forum 
-Tested up to: 6.8 
-Stable tag: nightly 
-License: GPL 3.0 or later 
+Tested up to: 7.0 
+Stable tag: 1.2.0 
+License: GPLv3 or later 
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 Form plugin for hametuha.

--- a/app/Hametuha/Thread/Pattern/RushDetector.php
+++ b/app/Hametuha/Thread/Pattern/RushDetector.php
@@ -52,7 +52,7 @@ class RushDetector {
 			return $old < $time;
 		} );
 		$rushing    = count( $activities ) >= $condition['limit'];
-		return (bool) apply_filters( 'hameturead_is_user_rushing', $rushing, $user_id, $activities );
+		return (bool) apply_filters( 'hamethread_is_user_rushing', $rushing, $user_id, $activities );
 	}
 
 	/**

--- a/hamethread.php
+++ b/hamethread.php
@@ -10,7 +10,8 @@
  * Author URI:        https://hametuha.co.jp
  * Text Domain:       hamethread
  * Domain Path:       /languages
- * License:           GPL3 or Later
+ * License:           GPLv3 or later
+ * License URI:       https://www.gnu.org/licenses/gpl-3.0.html
  * @package           hamethread
  */
 


### PR DESCRIPTION
#52 の続き。ビルド成果物に対して `WordPress/plugin-check-action` を回すワークフローの**検証用ドラフト**。

成果物には readme.txt が生成されるため `no_plugin_readme` は解消するはず。代わりに readme/メタの内容チェック（tested-up-to / license など）が残るかを確認し、#51(readme) と #50-A(ライセンス) の確定todoを得るのが目的。

Refs #52